### PR TITLE
Render Clue of the Day text on Clues of the Day

### DIFF
--- a/lib/clue-of-the-day.js
+++ b/lib/clue-of-the-day.js
@@ -36,13 +36,16 @@ export default function clueOfTheDay(cotd) {
                     day: 'numeric',
                     year: 'numeric',
                 }),
-                clue_title: 'Clue of the Day: ' + new Date(date).toLocaleString('en-GB', {
-                    weekday: "short",
-                    day: "numeric",
-                    month: "short",
-                    year: "numeric",
-                })
-                .replace(",", "")
+                clue_title:
+                    'Clue of the Day: ' +
+                    new Date(date)
+                        .toLocaleString('en-GB', {
+                            weekday: 'short',
+                            day: 'numeric',
+                            month: 'short',
+                            year: 'numeric',
+                        })
+                        .replace(',', ''),
             };
         })
         .reverse();

--- a/lib/clue-of-the-day.js
+++ b/lib/clue-of-the-day.js
@@ -36,7 +36,7 @@ export default function clueOfTheDay(cotd) {
                     day: 'numeric',
                     year: 'numeric',
                 }),
-                cotd_title: 'Clue of the Day: ' + new Date(date).toLocaleString('en-GB', {
+                clue_title: 'Clue of the Day: ' + new Date(date).toLocaleString('en-GB', {
                     weekday: "short",
                     day: "numeric",
                     month: "short",

--- a/lib/clue-of-the-day.js
+++ b/lib/clue-of-the-day.js
@@ -36,6 +36,13 @@ export default function clueOfTheDay(cotd) {
                     day: 'numeric',
                     year: 'numeric',
                 }),
+                cotd_title: 'Clue of the Day: ' + new Date(date).toLocaleString('en-GB', {
+                    weekday: "short",
+                    day: "numeric",
+                    month: "short",
+                    year: "numeric",
+                })
+                .replace(",", "")
             };
         })
         .reverse();

--- a/partials/_solve.html
+++ b/partials/_solve.html
@@ -146,7 +146,7 @@
 </style>
 
 <section class="card card--clue" style="height: 30svh">
-    <div class="card__header">{{cotd_title}}</div>
+    <div class="card__header">{{clue_title}}</div>
     <p id="clue"></p>
     <div class="card__footer">
         <span>Author: </span>

--- a/partials/_solve.html
+++ b/partials/_solve.html
@@ -117,7 +117,7 @@
         display: none;
     }
 
-    .card__top {
+    #clue {
         text-align: center;
         font-size: x-large;
         margin-top: auto;
@@ -126,14 +126,32 @@
         height: auto;
         display: block;
     }
+
+    .card__header,
+    .card__footer {
+        --card-separator: solid 2px var(--colour-active);
+        font-size: medium;
+        font-weight: normal;
+        text-align: center;
+        margin: 0;
+    }
+
+    .card__header:not(:empty) {
+        border-bottom: var(--card-separator);
+    }
+
+    .card__footer:not(:empty) {
+        border-top: var(--card-separator);
+    }
 </style>
 
 <section class="card card--clue" style="height: 30svh">
-    <span class="card__top" id="clue"></span>
-    <span class="card__title">
+    <div class="card__header">{{cotd_title}}</div>
+    <p id="clue"></p>
+    <div class="card__footer">
         <span>Author: </span>
         <span id="author"></span>
-    </span>
+    </div>
 </section>
 <dialog class="card hint-dialog">
     <span class="hint header" id="hint"></span>


### PR DESCRIPTION
This PR adjusts the COTD parsing logic so that it outputs a `clue_title` template parameter.

The `clue_title` template parameter is used on the `solve` path to fill in a new part of the clue card, appearing above the clue.

The card has been changed to now have a `card__header` and `card__footer`, which include the separator onlyif they are nonempty.

Here's how it looks with the COTD title set:
<img width="391" height="210" alt="image" src="https://github.com/user-attachments/assets/03a5ab40-e04f-48c9-a83b-80103f0d9f37" />
Without the COTD title set, clues are visually identical to before, with one extra empty element (`card__header`) taking up no space.